### PR TITLE
Add SolidusSupport.payment_source_parent_class

### DIFF
--- a/lib/solidus_support.rb
+++ b/lib/solidus_support.rb
@@ -15,5 +15,13 @@ module SolidusSupport
         Gem::Specification.detect{|x| x.name == "solidus_core" }.version
       end
     end
+
+    def payment_source_parent_class
+      if solidus_gem_version > Gem::Version.new('2.2.x')
+        Spree::PaymentSource
+      else
+        Spree::Base
+      end
+    end
   end
 end


### PR DESCRIPTION
This allows extensions to inherit from PaymentSource while still supporting
older versions of Solidus.