### PR TITLE
Add a basic spec_helper for extensions to include

### DIFF
--- a/lib/solidus_support/extension/feature_helper.rb
+++ b/lib/solidus_support/extension/feature_helper.rb
@@ -1,0 +1,29 @@
+# A basic feature_helper to be included as the starting point for extensions
+#
+# Can be required from an extension's spec/feature_helper.rb
+#
+#     require 'solidus_support/extension/feature_helper.rb'
+#
+
+require 'solidus_support/extension/rails_helper'
+
+require 'capybara-screenshot/rspec'
+require 'capybara/poltergeist'
+
+Capybara.register_driver :poltergeist do |app|
+  Capybara::Poltergeist::Driver.new(app, js_errors: true, timeout: 90)
+end
+
+Capybara.javascript_driver = :poltergeist
+Capybara.default_max_wait_time = 10
+
+require 'spree/testing_support/capybara_ext'
+
+RSpec.configure do |config|
+  config.when_first_matching_example_defined(type: :feature) do
+    config.before :suite do
+      # Preload assets
+      Rails.application.precompiled_assets
+    end
+  end
+end

--- a/lib/solidus_support/extension/rails_helper.rb
+++ b/lib/solidus_support/extension/rails_helper.rb
@@ -1,0 +1,40 @@
+# A basic rails_helper to be included as the starting point for extensions
+#
+# Can be required from an extension's spec/rails_helper.rb
+#
+#     require 'solidus_support/extension/rails_helper.rb'
+#
+
+require 'solidus_support/extension/spec_helper'
+
+require 'rspec/rails'
+require 'database_cleaner'
+require 'ffaker'
+
+require 'spree/testing_support/authorization_helpers'
+require 'spree/testing_support/factories'
+require 'spree/testing_support/url_helpers'
+
+RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
+
+  # visit spree.admin_path
+  # current_path.should eql(spree.products_path)
+  config.include Spree::TestingSupport::UrlHelpers
+
+  # Ensure Suite is set to use transactions for speed.
+  config.before :suite do
+    DatabaseCleaner.clean_with :truncation
+  end
+
+  # Before each spec check if it is a Javascript test and switch between using database transactions or not where necessary.
+  config.before :each do
+    DatabaseCleaner.strategy = RSpec.current_example.metadata[:js] ? :truncation : :transaction
+    DatabaseCleaner.start
+  end
+
+  # After each spec clean the database.
+  config.after :each do
+    DatabaseCleaner.clean
+  end
+end

--- a/lib/solidus_support/extension/spec_helper.rb
+++ b/lib/solidus_support/extension/spec_helper.rb
@@ -1,0 +1,19 @@
+# A basic spec_helper to be included as the starting point for extensions
+#
+# Can be required from an extension's spec/spec_helper.rb
+#
+#     require 'solidus_support/extension/spec_helper.rb'
+#
+
+RSpec.configure do |config|
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
+
+  config.mock_with :rspec
+  config.color = true
+
+  config.fail_fast = ENV['FAIL_FAST'] || false
+  config.order = 'random'
+
+  Kernel.srand config.seed
+end


### PR DESCRIPTION
An example of how this would be used:

https://github.com/jhawthorn/solidus_gateway/blob/68ac85ae801fb41e2ee3486f08ce91122b5e93e5/spec/spec_helper.rb