### PR TITLE
Add ffaker dependency to gemspec

### DIFF
--- a/solidus_support.gemspec
+++ b/solidus_support.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'ffaker'
+
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
ffaker was removed as a runtime dependency of Solidus.

This gem itself requires ffaker:
`lib/solidus_support/extensions/rails_helper.rb`

Every Solidus extension that does not include ffaker will be broken.
Adding the ffaker dependency here will fix all of the reverse
dependencies of this gem:
https://rubygems.org/gems/solidus_support/reverse_dependencies

PR removing ffaker from Solidus:
https://github.com/solidusio/solidus/pull/2163