### PR TITLE
Add payment method parent class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/log/

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+sudo: false
+language: ruby
+dist: trusty
+cache:
+  bundler: true
+before_install:
+  - "gem install bundler --pre"
+  - "bundler -v"
+rvm:
+  - 2.4.2
+env:
+  matrix:
+    - SOLIDUS_BRANCH=v1.0
+    - SOLIDUS_BRANCH=v1.1
+    - SOLIDUS_BRANCH=v1.2
+    - SOLIDUS_BRANCH=v1.3
+    - SOLIDUS_BRANCH=v1.4
+    - SOLIDUS_BRANCH=v2.0
+    - SOLIDUS_BRANCH=v2.1
+    - SOLIDUS_BRANCH=v2.2
+    - SOLIDUS_BRANCH=v2.3
+    - SOLIDUS_BRANCH=v2.4
+    - SOLIDUS_BRANCH=master

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,10 @@
 source 'https://rubygems.org'
 
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
-gem 'solidus', github: 'solidusio/solidus', branch: branch
+gem 'solidus_core', github: 'solidusio/solidus', branch: branch
 
 # Specify your gem's dependencies in solidus_support.gemspec
 gemspec
+
+gem 'sqlite3'
+gem 'sprockets-rails'

--- a/lib/solidus_support.rb
+++ b/lib/solidus_support.rb
@@ -24,6 +24,18 @@ module SolidusSupport
       end
     end
 
+    def payment_method_parent_class(credit_card: false)
+      if credit_card
+        if solidus_gem_version >= Gem::Version.new('2.3.x')
+          Spree::PaymentMethod::CreditCard
+        else
+          Spree::Gateway
+        end
+      else
+        Spree::PaymentMethod
+      end
+    end
+
     def frontend_available?
       defined?(Spree::Frontend::Engine)
     end

--- a/solidus_support.gemspec
+++ b/solidus_support.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_development_dependency "solidus_core"
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec-rails", "~> 3.7"
 end

--- a/spec/solidus_support_spec.rb
+++ b/spec/solidus_support_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe SolidusSupport do
+  describe '.payment_method_parent_class' do
+    subject { described_class.payment_method_parent_class(credit_card: credit_card) }
+
+    let(:credit_card) { nil }
+
+    it { is_expected.to eq(Spree::PaymentMethod) }
+
+    context 'with credit_card: true' do
+      let(:credit_card) { true }
+
+      before do
+        expect(described_class).to receive(:solidus_gem_version) do
+          Gem::Version.new(solidus_version)
+        end
+      end
+
+      context 'For Solidus < 2.3' do
+        let(:solidus_version) { '2.2.x' }
+        it { is_expected.to eq(Spree::Gateway) }
+      end
+
+      context 'For Solidus >= 2.3' do
+        let(:solidus_version) { '2.3.x' }
+        it { is_expected.to eq(Spree::PaymentMethod::CreditCard) }
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require_relative 'support/dummy_app'
+require 'solidus_support/extension/spec_helper'

--- a/spec/support/dummy_app.rb
+++ b/spec/support/dummy_app.rb
@@ -1,0 +1,18 @@
+ENV['RAILS_ENV'] = 'test'
+ENV['DISABLE_DATABASE_ENVIRONMENT_CHECK'] = '1'
+
+Bundler.setup
+
+require 'rails'
+require 'solidus_core'
+
+Bundler.require(:default, :test)
+
+module DummyApp
+  class Application < ::Rails::Application
+    config.eager_load               = false
+    config.paths["config/database"] = File.expand_path('../dummy_app/database.yml', __FILE__)
+  end
+end
+
+DummyApp::Application.initialize!

--- a/spec/support/dummy_app/database.yml
+++ b/spec/support/dummy_app/database.yml
@@ -1,0 +1,4 @@
+test:
+  adapter: sqlite3
+  database: ':memory:'
+  timeout: 10000


### PR DESCRIPTION
Add `SolidusSupport.payment_method_parent_class`

This helps to get the parent class for payment methods.

For Solidus < 2.3 it is `Spree::PaymentMethod` for non credit card payment methods or `Spree::Gateway` for credit card payment methods.

For Solidus >= 2.3 it is `Spree::PaymentMethod` for non credit card payment methods or `Spree::PaymentMethod::CreditCard` for credit card payment methods.

#### Usage:

```rb
My::NonCreditCardPaymentMethod < SolidusSupport.payment_method_parent_class
```

```rb
My::CreditCardPaymentMethod < SolidusSupport.payment_method_parent_class(credit_card: true)
```

- Also adds a test suite