### PR TITLE
Fix how we compare gem versions to determine new gateway code usage

### DIFF
--- a/lib/solidus_support.rb
+++ b/lib/solidus_support.rb
@@ -16,8 +16,13 @@ module SolidusSupport
       end
     end
 
+    def new_gateway_code?
+      first_version_with_new_gateway_code = Gem::Requirement.new('>= 2.3')
+      first_version_with_new_gateway_code.satisfied_by?(solidus_gem_version)
+    end
+
     def payment_source_parent_class
-      if solidus_gem_version > Gem::Version.new('2.2.x')
+      if new_gateway_code?
         Spree::PaymentSource
       else
         Spree::Base
@@ -25,14 +30,14 @@ module SolidusSupport
     end
 
     def payment_method_parent_class(credit_card: false)
-      if credit_card
-        if solidus_gem_version >= Gem::Version.new('2.3.x')
+      if new_gateway_code?
+        if credit_card
           Spree::PaymentMethod::CreditCard
         else
-          Spree::Gateway
+          Spree::PaymentMethod
         end
       else
-        Spree::PaymentMethod
+        Spree::Gateway
       end
     end
 

--- a/spec/solidus_support_spec.rb
+++ b/spec/solidus_support_spec.rb
@@ -4,24 +4,36 @@ RSpec.describe SolidusSupport do
 
     let(:credit_card) { nil }
 
-    it { is_expected.to eq(Spree::PaymentMethod) }
+    before do
+      allow(described_class).to receive(:solidus_gem_version) do
+        Gem::Version.new(solidus_version)
+      end
+    end
+
+    context 'For Solidus < 2.3' do
+      let(:solidus_version) { '2.2.1' }
+
+      it { is_expected.to eq(Spree::Gateway) }
+    end
+
+    context 'For Solidus >= 2.3' do
+      let(:solidus_version) { '2.3.1' }
+
+      it { is_expected.to eq(Spree::PaymentMethod) }
+    end
 
     context 'with credit_card: true' do
       let(:credit_card) { true }
 
-      before do
-        expect(described_class).to receive(:solidus_gem_version) do
-          Gem::Version.new(solidus_version)
-        end
-      end
-
       context 'For Solidus < 2.3' do
-        let(:solidus_version) { '2.2.x' }
+        let(:solidus_version) { '2.2.1' }
+
         it { is_expected.to eq(Spree::Gateway) }
       end
 
       context 'For Solidus >= 2.3' do
-        let(:solidus_version) { '2.3.x' }
+        let(:solidus_version) { '2.3.1' }
+
         it { is_expected.to eq(Spree::PaymentMethod::CreditCard) }
       end
     end


### PR DESCRIPTION
This PR fixes how we are comparing gem versions to understand if we need to use the new payment gateway related class as parents of our extensions' classes.
It also fixes the logic into the payment_method_parent_class which was wrong.