### PR TITLE
Remove running rubocop on rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,5 +7,5 @@ begin
   RuboCop::RakeTask.new
   RSpec::Core::RakeTask.new(:spec)
 
-  task default: %i[rubocop spec]
+  task default: %i[spec]
 end


### PR DESCRIPTION
As pointed out [here](https://github.com/solidusio/solidus_support/pull/13#pullrequestreview-162995245) this is something worth a discussion at least. Sorry for merging without a review! 