### PR TITLE
Remove ffaker

### DIFF
--- a/lib/solidus_support/extension/rails_helper.rb
+++ b/lib/solidus_support/extension/rails_helper.rb
@@ -9,7 +9,6 @@ require 'solidus_support/extension/spec_helper'
 
 require 'rspec/rails'
 require 'database_cleaner'
-require 'ffaker'
 
 require 'spree/testing_support/authorization_helpers'
 require 'spree/testing_support/factories'


### PR DESCRIPTION
Following https://github.com/solidusio/solidus/pull/2339

When working with extensions, it's required to add ffaker to the Gemfile even when is no longer used.