### PR TITLE
Migrate from Poltergeist to Headless Chrome

### DIFF
--- a/lib/solidus_support/extension/feature_helper.rb
+++ b/lib/solidus_support/extension/feature_helper.rb
@@ -8,13 +8,21 @@
 require 'solidus_support/extension/rails_helper'
 
 require 'capybara-screenshot/rspec'
-require 'capybara/poltergeist'
+require 'selenium/webdriver'
 
-Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, js_errors: true, timeout: 90)
+Capybara.register_driver :selenium_chrome_headless do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w[headless start-maximized] }
+  )
+
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :chrome,
+    desired_capabilities: capabilities
+  )
 end
 
-Capybara.javascript_driver = :poltergeist
+Capybara.javascript_driver = :selenium_chrome_headless
 Capybara.default_max_wait_time = 10
 
 require 'spree/testing_support/capybara_ext'


### PR DESCRIPTION
Since we're already using Headless Chrome on Solidus, we might as well do so with its extensions to achieve a consistent development environment, so this PR aims to migrate from Poltergeist to Headless Chrome.

Take into consideration that this PR (once merged) will affect **every** Solidus extension that uses this gem's base spec helper.