### PR TITLE
Override Capybara JS driver via `CAPYBARA_DRIVER` ENV variable

### DIFF
--- a/lib/solidus_support/extension/feature_helper.rb
+++ b/lib/solidus_support/extension/feature_helper.rb
@@ -22,7 +22,7 @@ Capybara.register_driver :selenium_chrome_headless do |app|
   )
 end
 
-Capybara.javascript_driver = :selenium_chrome_headless
+Capybara.javascript_driver = (ENV['CAPYBARA_DRIVER'] || :selenium_chrome_headless).to_sym
 Capybara.default_max_wait_time = 10
 
 require 'spree/testing_support/capybara_ext'


### PR DESCRIPTION
By setting locally the ENV variable `CAPYBARA_DRIVER` it's now possible to
override the default JS driver (currently `selenium_chrome_headless`).