### PR TITLE
Update Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ rvm:
   - 2.4.2
 env:
   matrix:
-    - SOLIDUS_BRANCH=v2.2
     - SOLIDUS_BRANCH=v2.3
     - SOLIDUS_BRANCH=v2.4
     - SOLIDUS_BRANCH=v2.5
     - SOLIDUS_BRANCH=v2.6
     - SOLIDUS_BRANCH=v2.7
+    - SOLIDUS_BRANCH=v2.8
     - SOLIDUS_BRANCH=master

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ rvm:
   - 2.4.2
 env:
   matrix:
-    - SOLIDUS_BRANCH=v2.3
     - SOLIDUS_BRANCH=v2.4
     - SOLIDUS_BRANCH=v2.5
     - SOLIDUS_BRANCH=v2.6


### PR DESCRIPTION
This patch:

* Removes Solidus v2.2
* Adds Solidus v2.8

As per @kennyadsl's request, this PR also removes support for Solidus v2.3 as tomorrow (**01/31/19**) is the last day before reaching EOL; this patch should only be merged **past** the date previously mentioned.