### PR TITLE
Do not reset spree preferences starting from v2.9

### DIFF
--- a/lib/solidus_support.rb
+++ b/lib/solidus_support.rb
@@ -16,6 +16,11 @@ module SolidusSupport
       end
     end
 
+    def reset_spree_preferences_deprecated?
+      first_version_without_reset = Gem::Requirement.new('>= 2.9')
+      first_version_without_reset.satisfied_by?(solidus_gem_version)
+    end
+
     def new_gateway_code?
       first_version_with_new_gateway_code = Gem::Requirement.new('>= 2.3')
       first_version_with_new_gateway_code.satisfied_by?(solidus_gem_version)

--- a/lib/solidus_support/extension/rails_helper.rb
+++ b/lib/solidus_support/extension/rails_helper.rb
@@ -15,6 +15,7 @@ require 'spree/testing_support/authorization_helpers'
 require 'spree/testing_support/factories'
 require 'spree/testing_support/url_helpers'
 require 'spree/testing_support/preferences'
+require 'solidus_support/testing_support/preferences'
 
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
@@ -24,6 +25,7 @@ RSpec.configure do |config|
   config.include Spree::TestingSupport::UrlHelpers
 
   config.include Spree::TestingSupport::Preferences
+  config.include SolidusSupport::TestingSupport::Preferences
 
   config.before :suite do
     DatabaseCleaner.clean_with :truncation

--- a/lib/solidus_support/extension/rails_helper.rb
+++ b/lib/solidus_support/extension/rails_helper.rb
@@ -35,7 +35,7 @@ RSpec.configure do |config|
     DatabaseCleaner.strategy = RSpec.current_example.metadata[:js] ? :truncation : :transaction
 
     DatabaseCleaner.cleaning do
-      reset_spree_preferences
+      reset_spree_preferences unless SolidusSupport.reset_spree_preferences_deprecated?
 
       example.run
     end

--- a/lib/solidus_support/testing_support/preferences.rb
+++ b/lib/solidus_support/testing_support/preferences.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module SolidusSupport
+  module TestingSupport
+    module Preferences
+      # This wrapper method allows to stub spree preferences using
+      # the new standard way of solidus core but also works with
+      # old versions that does not have the stub_spree_preferences
+      # method yet. This way we can start using this method in our
+      # extensions safely.
+      #
+      # To have this available, it is needed to require in the
+      # spec/spec_helper.rb of the extension both:
+      #
+      # require 'spree/testing_support/preferences'
+      # require 'solidus_support/testing_support/preferences'
+      #
+      # @example Set a preference on Spree::Config
+      #   stub_spree_preferences(allow_guest_checkout: false)
+      #
+      # @example Set a preference on Spree::Api::Config
+      #   stub_spree_preferences(Spree::Api::Config, requires_authentication: false)
+      #
+      # @example Set a preference on a custom Spree::CustomExtension::Config
+      #  stub_spree_preferences(Spree::CustomExtension::Config, custom_pref: true)
+      #
+      # @param prefs_or_conf_class [Class, Hash] the class we want to stub
+      #   preferences for or the preferences hash (see prefs param). If this
+      #   param is an Hash, preferences will be stubbed on Spree::Config.
+      # @param prefs [Hash, nil] names and values to be stubbed
+      def stub_spree_preferences(prefs_or_conf_class, prefs = nil)
+        super && return if SolidusSupport.reset_spree_preferences_deprecated?
+
+        if prefs_or_conf_class.is_a?(Hash)
+          preference_store_class = Spree::Config
+          preferences = prefs_or_conf_class
+        else
+          preference_store_class = prefs_or_conf_class
+          preferences = prefs
+        end
+        preference_store_class.set(preferences)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We need this to remove deprecation warnings into extensions. Of course, this could let some spec fail on 2.9 or master.

This PR stops resetting preferences after each spec run and provides an alternative method to use into extensions (and stores) specs. This method will work for all supported Solidus versions and it will be easy to remove later since they have the same signature: we can just remove the `require 'solidus_support/testing_support/preferences'` for solidus support `rails_helper` without any change in the extensions.