### PR TITLE
Add `capybara-screenshot` dependency

### DIFF
--- a/solidus_support.gemspec
+++ b/solidus_support.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'solidus_core'
+  spec.add_dependency 'capybara-screenshot'
 end


### PR DESCRIPTION
Although the gem was not explicitly listed as a code dependecy it is actually
required in file `extension/feature_helper.rb`:
```ruby
  require 'capybara-screenshot/rspec'
```

So, gems that `require 'extension/feature_helper.rb'` can now avoid to explicitly list `capybara-screenshot` among their dependencies.