### PR TITLE
Add SolidusSupport::EngineExtension::Decorators to load decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,38 @@ SolidusSupport::Migration[5.0] # same as `ActiveRecord::Migration[5.0]`
 
 There's no reason to use `SolidusSupport::Migration[5.0]` over `ActiveRecord::Migration[5.0]`, but it is provided.
 
+### Engine Extensions
+
+This extension provides a module that extends `Rails::Engine` functionalities
+to support loading correctly the decorators class created into an extension
+both for development and production enviroments.
+
+To use it just include the provided module in the Engine as follow:
+
+```ruby
+module SolidusExtensionName
+  class Engine < Rails::Engine
+    engine_name 'solidus_extension_name'
+
+    include SolidusSupport::EngineExtensions::Decorators
+    # ...
+  end
+end
+```
+
+To make it work, be sure to remove the previous implementation from the
+Engine, that should be something like:
+
+```ruby
+def self.activate
+  Dir.glob(File.join(root, "app/**/*_decorator*.rb")) do |c|
+    Rails.configuration.cache_classes ? require(c) : load(c)
+  end
+end
+
+config.to_prepare(&method(:activate).to_proc)
+```
+
 ### Testing Helpers
 
 This gem provides some useful helpers for RSpec to setup an extension's test

--- a/lib/solidus_support.rb
+++ b/lib/solidus_support.rb
@@ -1,5 +1,6 @@
 require 'solidus_support/version'
 require 'solidus_support/migration'
+require 'solidus_support/engine_extensions'
 require 'solidus_core'
 
 module SolidusSupport

--- a/lib/solidus_support/engine_extensions.rb
+++ b/lib/solidus_support/engine_extensions.rb
@@ -1,0 +1,1 @@
+require_relative 'engine_extensions/decorators'

--- a/lib/solidus_support/engine_extensions/decorators.rb
+++ b/lib/solidus_support/engine_extensions/decorators.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module SolidusSupport
+  module EngineExtensions
+    module Decorators
+      def self.included(engine)
+        engine.class_eval do
+          extend ClassMethods
+          config.to_prepare(&method(:activate).to_proc)
+        end
+      end
+
+      module ClassMethods
+        def activate
+          base_path = root.join('app/decorators')
+
+          if Rails.respond_to?(:autoloaders)
+            # Add decorators folder to the Rails autoloader. This
+            # allows Zeitwerk to resolve decorators paths correctly,
+            # when used.
+            Dir.glob(base_path.join('*')) do |decorators_folder|
+              Rails.autoloaders.main.push_dir(decorators_folder)
+            end
+          end
+
+          # Load decorator files. This is needed since they are
+          # never explicitely referenced in the application code
+          # and won't be loaded by default. We need them to be
+          # executed anyway to extend exisiting classes.
+          Dir.glob(base_path.join('**/*.rb')) do |decorator_path|
+            Rails.configuration.cache_classes ? require(decorator_path) : load(decorator_path)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This module is supposed to be used in extensions engines to remove boilerplate code from gem engines.

As is right now, it loads all the decorators correctly for both development and production environment, since we were having some issues with Zeitwerk not loading decorators in production.

**Instructions**

To use it just extend the Engine with the provided module as follow:

```ruby
module SolidusExtensionName
  class Engine < Rails::Engine
    engine_name 'solidus_extension_name'
    inlcude SolidusSupport::EngineExtensions::Decorators
    # ...
  end
end
```

To make it work, be sure to remove the previous implementation from the
Engine, that should be something like:

```ruby
def self.activate
  Dir.glob(File.join(root, "app/**/*_decorator*.rb")) do |c|
    Rails.configuration.cache_classes ? require(c) : load(c)
  end
end

config.to_prepare(&method(:activate).to_proc)
```