### PR TITLE
Introduce solidus_extension_dev_tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /spec/reports/
 /tmp/
 /log/
+/spec/
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,2 @@
-Metrics/BlockLength:
-  ExcludedMethods: ['describe', 'context']
-
-Metrics/LineLength:
-  Max: 100
-
-Style/Documentation:
-  Enabled: false
+require:
+  - solidus_extension_dev_tools/rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 branch = ENV.fetch('SOLIDUS_BRANCH', 'master')

--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,6 @@ gem 'solidus_core', github: 'solidusio/solidus', branch: branch
 # Specify your gem's dependencies in solidus_support.gemspec
 gemspec
 
+gem 'solidus_extension_dev_tools', github: 'solidusio-contrib/solidus_extension_dev_tools'
 gem 'sprockets-rails'
 gem 'sqlite3'

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler'
 
 begin

--- a/lib/solidus_support.rb
+++ b/lib/solidus_support.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'solidus_support/version'
 require 'solidus_support/migration'
 require 'solidus_support/engine_extensions'

--- a/lib/solidus_support/engine_extensions.rb
+++ b/lib/solidus_support/engine_extensions.rb
@@ -1,1 +1,3 @@
+# frozen_string_literal: true
+
 require_relative 'engine_extensions/decorators'

--- a/lib/solidus_support/migration.rb
+++ b/lib/solidus_support/migration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SolidusSupport
   module Migration
     def self.[](version)

--- a/lib/solidus_support/version.rb
+++ b/lib/solidus_support/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SolidusSupport
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.4.0'
 end

--- a/solidus_support.gemspec
+++ b/solidus_support.gemspec
@@ -17,10 +17,11 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0")
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.14'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec-rails', '~> 3.7'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'solidus_core'
+  spec.add_development_dependency 'solidus_extension_dev_tools'
 end

--- a/spec/solidus_support_spec.rb
+++ b/spec/solidus_support_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe SolidusSupport do
   describe '.payment_method_parent_class' do
     subject { described_class.payment_method_parent_class(credit_card: credit_card) }
@@ -10,32 +12,34 @@ RSpec.describe SolidusSupport do
       end
     end
 
-    context 'For Solidus < 2.3' do
+    context 'with Solidus < 2.3' do
       let(:solidus_version) { '2.2.1' }
 
       it { is_expected.to eq(Spree::Gateway) }
     end
 
-    context 'For Solidus >= 2.3' do
+    context 'with Solidus >= 2.3' do
       let(:solidus_version) { '2.3.1' }
 
       it { is_expected.to eq(Spree::PaymentMethod) }
     end
 
+    # rubocop:disable RSpec/NestedGroups
     context 'with credit_card: true' do
       let(:credit_card) { true }
 
-      context 'For Solidus < 2.3' do
+      context 'with Solidus < 2.3' do
         let(:solidus_version) { '2.2.1' }
 
         it { is_expected.to eq(Spree::Gateway) }
       end
 
-      context 'For Solidus >= 2.3' do
+      context 'with Solidus >= 2.3' do
         let(:solidus_version) { '2.3.1' }
 
         it { is_expected.to eq(Spree::PaymentMethod::CreditCard) }
       end
     end
+    # rubocop:enable RSpec/NestedGroups
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 require_relative 'support/dummy_app'
 require 'solidus_extension_dev_tools/rspec/spec_helper'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,2 @@
 require_relative 'support/dummy_app'
-require 'solidus_support/extension/spec_helper'
+require 'solidus_extension_dev_tools/rspec/spec_helper'

--- a/spec/support/dummy_app.rb
+++ b/spec/support/dummy_app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV['RAILS_ENV'] = 'test'
 ENV['DISABLE_DATABASE_ENVIRONMENT_CHECK'] = '1'
 


### PR DESCRIPTION
Installs [solidus_extension_dev_tools](https://github.com/solidusio-contrib/solidus_extension_dev_tools) and imports its RSpec and RuboCop configurations.