### PR TITLE
Fix issues with test runs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,12 @@ gemspec
 gem 'solidus_extension_dev_tools', github: 'solidusio-contrib/solidus_extension_dev_tools'
 gem 'sprockets', '~> 3'
 gem 'sprockets-rails'
-gem 'sqlite3'
+
+case ENV['DB']
+when 'postgresql'
+  gem 'pg'
+when 'mysql'
+  gem 'mysql2'
+else
+  gem 'sqlite3'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,6 @@ gem 'solidus_core', github: 'solidusio/solidus', branch: branch
 gemspec
 
 gem 'solidus_extension_dev_tools', github: 'solidusio-contrib/solidus_extension_dev_tools'
+gem 'sprockets', '~> 3'
 gem 'sprockets-rails'
 gem 'sqlite3'

--- a/spec/support/dummy_app/database.yml
+++ b/spec/support/dummy_app/database.yml
@@ -1,4 +1,16 @@
+<% if ENV['DB'] == 'postgresql' %>
+test:
+  adapter: postgresql
+  database: circle_test
+  username: root
+<% elsif ENV['DB'] == 'mysql' %>
+test:
+  adapter: mysql2
+  database: circle_test
+  username: root
+<% else %>
 test:
   adapter: sqlite3
   database: ':memory:'
   timeout: 10000
+<% end %>


### PR DESCRIPTION
This PR contains two fixes which allow us to run the tests for solidus_support both locally and in CI.

### ActiveRecord adapters

Fixes the gem for AR adapters not being loaded.

### Sprockets

Fixes an issue where Sprockets complains that there's no manifest file by locking to Sprockets 3. 

Unfortunately, Sprockets 4, which introduced manifests, doesn't support specifying a custom path for the assets manifest, which obviously doesn't work with in-memory apps.

@kennyadsl [submitted a PR](https://github.com/rails/sprockets-rails/pull/446) which would allow Sprockets to support custom manifest paths, but it was not merged yet.