### PR TITLE
Switch to the new dev_tools gem name in rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,2 @@
 require:
-  - solidus_extension_dev_tools/rubocop
+  - solidus_dev_support/rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem 'solidus_core', github: 'solidusio/solidus', branch: branch
 # Specify your gem's dependencies in solidus_support.gemspec
 gemspec
 
-gem 'solidus_dev_support', github: 'solidusio-contrib/solidus_dev_support'
 gem 'sprockets', '~> 3'
 gem 'sprockets-rails'
 


### PR DESCRIPTION
It has been renamed recently and it was added twice. I removed the Gemfile's dependency, which is not needed anymore.