### PR TITLE
Fixes isse when zeitwerk is not enabled

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'solidus_core', github: 'solidusio/solidus', branch: branch
 # Specify your gem's dependencies in solidus_support.gemspec
 gemspec
 
-gem 'solidus_extension_dev_tools', github: 'solidusio-contrib/solidus_extension_dev_tools'
+gem 'solidus_dev_support', github: 'solidusio-contrib/solidus_dev_support'
 gem 'sprockets', '~> 3'
 gem 'sprockets-rails'
 

--- a/lib/solidus_support/engine_extensions/decorators.rb
+++ b/lib/solidus_support/engine_extensions/decorators.rb
@@ -14,7 +14,7 @@ module SolidusSupport
         def activate
           base_path = root.join('app/decorators')
 
-          if Rails.respond_to?(:autoloaders)
+          if Rails.respond_to?(:autoloaders) && Rails.autoloaders.main
             # Add decorators folder to the Rails autoloader. This
             # allows Zeitwerk to resolve decorators paths correctly,
             # when used.

--- a/solidus_support.gemspec
+++ b/solidus_support.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'solidus_core'
-  spec.add_development_dependency 'solidus_extension_dev_tools'
+  spec.add_development_dependency 'solidus_dev_support'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 require_relative 'support/dummy_app'
-require 'solidus_extension_dev_tools/rspec/spec_helper'
+require 'solidus_dev_support/rspec/spec_helper'


### PR DESCRIPTION
If autoloaders is defined in the Rails object, but the autoloader zeitwerk is not used, it is defined but returns nil when calling `main`.

It is not enough to check [here](https://github.com/solidusio/solidus_support/blob/master/lib/solidus_support/engine_extensions/decorators.rb#L17) if autoloaders are enabled, it actually returns true, because it is registered, but if zeitwerk is disabled, `Rails.autoloaders.main` returns nil causing a no method error
```
solidus_support-0.4.0/lib/solidus_support/engine_extensions/decorators.rb:22:in `block in activate': undefined method `push_dir' for nil:NilClass (NoMethodError)
```
