### PR TITLE
Push decorators to autoload path using config.autoload_paths

### DIFF
--- a/lib/solidus_support/engine_extensions.rb
+++ b/lib/solidus_support/engine_extensions.rb
@@ -9,6 +9,10 @@ module SolidusSupport
       engine.extend ClassMethods
 
       engine.class_eval do
+        solidus_decorators_root.glob('*') do |decorators_folder|
+          config.autoload_paths += [decorators_folder]
+        end
+
         config.to_prepare(&method(:activate))
 
         enable_solidus_engine_support('backend') if SolidusSupport.backend_available?
@@ -19,14 +23,6 @@ module SolidusSupport
 
     module ClassMethods
       def activate
-        if Rails.respond_to?(:autoloaders) && Rails.autoloaders.main
-          # Add decorators folder to the Rails autoloader. This tells Zeitwerk to treat paths
-          # such as app/decorators/controllers as roots.
-          solidus_decorators_root.glob('*') do |decorators_folder|
-            Rails.autoloaders.main.push_dir(decorators_folder)
-          end
-        end
-
         load_solidus_decorators_from(solidus_decorators_root)
       end
 


### PR DESCRIPTION
This PR fixes a bug when decorators in `app/decorators` weren't properly reloaded when changing any other classes of the application. 

I verified this by opening a rails console on an extension's dummy app using this module and running:

```ruby
# Suppose we have a decorator called 
#   Spree::DecoratedCoreClassDecorator 
#
# that extends (via prepend) a core class called
#   Spree::DecoratedCoreClass
#
# the decorator is defined at:
#   extension_root/app/decorators/models/spree/decorated_core_class_decorator.rb

[1] pry(main)> Spree::DecoratedCoreClass.ancestors
=> [Spree::DecoratedCoreClassDecorator,
 Spree::DecoratedCoreClass,
 ActiveSupport::Dependencies::ZeitwerkIntegration::RequireDependency,
 ActiveSupport::ToJsonWithActiveSupportEncoder,
 Object,
 PP::ObjectMixin,
 FriendlyId::ObjectUtils,
 JSON::Ext::Generator::GeneratorMethods::Object,
 ActiveSupport::Tryable,
 ActiveSupport::Dependencies::Loadable,
 Kernel,
 BasicObject]

[2] pry(main)> reload!
Reloading...
=> true

[3] pry(main)> Spree::DecoratedCoreClass.ancestors
=> [Spree::DecoratedCoreClass,
 ActiveSupport::Dependencies::ZeitwerkIntegration::RequireDependency,
 ActiveSupport::ToJsonWithActiveSupportEncoder,
 Object,
 PP::ObjectMixin,
 FriendlyId::ObjectUtils,
 JSON::Ext::Generator::GeneratorMethods::Object,
 ActiveSupport::Tryable,
 ActiveSupport::Dependencies::Loadable,
 Kernel,
 BasicObject]
```

With this change, decorators are being correctly reloaded when some code in the application changes. 

Apparently, there's no need to push root_folders into Zeitwerk directly via `Rails.autoloaders.main.push_dir(decorators_folder)` and we can rely on `config.autoload_paths`. 

Another thing that I can't get yet is: we are calling `require_dependency` on all decorators with `load_solidus_decorators_from(solidus_decorators_root)` in the engine `to_prepare` method. This means that it's requiring the file again and again at each code reload. But if it was requiring the decorators at each code reload why we couldn't see it within the ancestors? Even if it wasn't autoloaded we should have been able to see it at that point.
