### PR TITLE
Add frontend/backend/api decorators to autoload path

### DIFF
--- a/lib/solidus_support/engine_extensions.rb
+++ b/lib/solidus_support/engine_extensions.rb
@@ -59,10 +59,13 @@ module SolidusSupport
         paths['app/controllers'] << "lib/controllers/#{engine}"
         paths['app/views'] << "lib/views/#{engine}"
 
+        path = root.join("lib/decorators/#{engine}")
+
+        config.autoload_paths += path.glob('*')
+
         engine_context = self
         config.to_prepare do
           engine_context.instance_eval do
-            path = root.join("lib/decorators/#{engine}")
             load_solidus_decorators_from(path)
           end
         end


### PR DESCRIPTION
This is required in order to have the decorators correctly unloaded when we reload the application (calling `reload!` in a Rails console or on each request in development).