### PR TITLE
Autoload Solidus Event subscribers from extensions

### DIFF
--- a/lib/solidus_support/engine_extensions.rb
+++ b/lib/solidus_support/engine_extensions.rb
@@ -24,6 +24,18 @@ module SolidusSupport
     module ClassMethods
       def activate
         load_solidus_decorators_from(solidus_decorators_root)
+        load_solidus_subscribers_from(solidus_subscribers_root)
+      end
+
+      # Loads Solidus event subscriber files.
+      #
+      # This allows to add event subscribers to extensions without explicitly subscribing them,
+      # similarly to what happens in Solidus core.
+      def load_solidus_subscribers_from(path)
+        path.glob("**/*_subscriber.rb") do |subscriber_path|
+          require_dependency(subscriber_path)
+        end
+        Spree::Event.subscribers.each(&:subscribe!)
       end
 
       # Loads decorator files.
@@ -44,6 +56,13 @@ module SolidusSupport
       # @return [Path]
       def solidus_decorators_root
         root.join('app/decorators')
+      end
+
+      # Returns the root for this engine's Solidus event subscribers.
+      #
+      # @return [Path]
+      def solidus_subscribers_root
+        root.join("app/subscribers")
       end
 
       # Enables support for a Solidus engine.


### PR DESCRIPTION
Just like it happens for Solidus core event subscribers and subscribers added by app developers, this change allows to automatically load and subscribe event subscriber files that are located inside Solidus extensions. 

See https://github.com/solidusio/solidus/pull/3571 for further details. 

Also, I created a [demo app](https://github.com/spaghetticode/solidus_event_subscribers_autoload) that shows the new feature at work and can be easily used to verify that code reload works as expected  with autoloaded event subscribers.