### PR TITLE
Stop using SolidusSupport.solidus_gem_version

### DIFF
--- a/lib/solidus_support.rb
+++ b/lib/solidus_support.rb
@@ -18,12 +18,12 @@ module SolidusSupport
 
     def reset_spree_preferences_deprecated?
       first_version_without_reset = Gem::Requirement.new('>= 2.9')
-      first_version_without_reset.satisfied_by?(solidus_gem_version)
+      first_version_without_reset.satisfied_by?(Spree.solidus_gem_version)
     end
 
     def new_gateway_code?
       first_version_with_new_gateway_code = Gem::Requirement.new('>= 2.3')
-      first_version_with_new_gateway_code.satisfied_by?(solidus_gem_version)
+      first_version_with_new_gateway_code.satisfied_by?(Spree.solidus_gem_version)
     end
 
     def payment_source_parent_class

--- a/spec/solidus_support_spec.rb
+++ b/spec/solidus_support_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SolidusSupport do
     let(:credit_card) { nil }
 
     before do
-      allow(described_class).to receive(:solidus_gem_version) do
+      allow(Spree).to receive(:solidus_gem_version) do
         Gem::Version.new(solidus_version)
       end
     end


### PR DESCRIPTION
The local method is deprecated, and suggests to use directly the one on the `Spree` namespace.