### PR TITLE
Load event subscribers only when Spree::Event is available

### DIFF
--- a/lib/solidus_support/engine_extensions.rb
+++ b/lib/solidus_support/engine_extensions.rb
@@ -32,10 +32,12 @@ module SolidusSupport
       # This allows to add event subscribers to extensions without explicitly subscribing them,
       # similarly to what happens in Solidus core.
       def load_solidus_subscribers_from(path)
-        path.glob("**/*_subscriber.rb") do |subscriber_path|
-          require_dependency(subscriber_path)
+        if defined? Spree::Event
+          path.glob("**/*_subscriber.rb") do |subscriber_path|
+            require_dependency(subscriber_path)
+          end
+          Spree::Event.subscribers.each(&:subscribe!)
         end
-        Spree::Event.subscribers.each(&:subscribe!)
       end
 
       # Loads decorator files.


### PR DESCRIPTION
This extension may be used with some old version of Solidus that does not include events, so we need to skip event subscribers loading when this happens.