### PR TITLE
Remove redundant `solidus_core` dev dependency

### DIFF
--- a/solidus_support.gemspec
+++ b/solidus_support.gemspec
@@ -28,6 +28,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'rubocop-rspec'
-  s.add_development_dependency 'solidus_core'
   s.add_development_dependency 'solidus_dev_support'
 end


### PR DESCRIPTION
When I was testing the 0.5.1 release on my local machine, running `bundle install` showed the following warning:

```
Your Gemfile lists the gem solidus_core (>= 0) more than once.
You should probably keep only one of them.
Remove any duplicate entries and specify the gem only once.
While it's not a problem now, it could cause errors if you change the version of one of them later.
```

It looks like if we already require `solidus_core` in the Gemfile here:

https://github.com/solidusio/solidus_support/blob/1683eb6a1e6948c5638d8f60bab8cec343fb85bd/Gemfile#L7

Then we don't need to also include it as a development dependency in `solidus_support.gemspec`.