### PR TITLE
Support Rails 5.1.x

### DIFF
--- a/solidus_support.gemspec
+++ b/solidus_support.gemspec
@@ -21,8 +21,6 @@ Gem::Specification.new do |s|
   s.executables = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'activesupport', ['>= 5.2', '< 7.0.x']
-
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec-rails'

--- a/spec/support/dummy_app.rb
+++ b/spec/support/dummy_app.rb
@@ -14,7 +14,7 @@ module DummyApp
   class Application < ::Rails::Application
     config.eager_load               = false
     config.paths['config/database'] = File.expand_path('dummy_app/database.yml', __dir__)
-    config.active_record.sqlite3.represent_boolean_as_integer = true
+    config.active_record.sqlite3.represent_boolean_as_integer = true unless Gem::Version.new(Rails.version) < Gem::Version.new('5.2')
   end
 end
 


### PR DESCRIPTION
All of the currently released Solidus versions still support Rails 5.1.x, and I think it's important to try to continue to support it as long as possible in this extension in particular.

_Many_ Solidus extensions rely on `solidus_support` v 0.5 and greater, and at the moment our store cannot get any of the latest commits from `solidus_tax_cloud` or `solidus_handling_fees` or `solidus_stripe` or `solidus_related_products` or . . . you get the idea . . . until we transition our application to Rails 5.2. (This is a huge undertaking, because it means somehow getting away from the deprecated `solidus_active_shipping`!)

Because this extension is so widely used (indeed that's the whole idea!), I believe it is important to have compatibility requirements that are as loose as possible, otherwise any requirements here will constrain the _entire_ ecosystem of a user's Solidus extensions.

I'm not familiar with what if anything changed in `activesupport` from v5.1 to 5.2, but all of the specs are green and, as I say, all current versions of Solidus support 5.1 so I think we should endeavor to continue to do so until there is a convincing reason otherwise!