### PR TITLE
Use `Spree::Event. activate_all_subscribers` when available

### DIFF
--- a/lib/solidus_support/engine_extensions.rb
+++ b/lib/solidus_support/engine_extensions.rb
@@ -36,7 +36,12 @@ module SolidusSupport
           path.glob("**/*_subscriber.rb") do |subscriber_path|
             require_dependency(subscriber_path)
           end
-          Spree::Event.subscribers.each(&:subscribe!)
+
+          if Spree::Event.respond_to?(:activate_all_subscribers)
+            Spree::Event.activate_all_subscribers
+          else
+            Spree::Event.subscribers.each(&:subscribe!)
+          end
         end
       end
 


### PR DESCRIPTION
The new method `Spree::Event. activate_all_subscribers` is introduced in Solidus with solidusio/solidus#3758 as a better way to subscribe event subscribers: under the hood, event subscribers use new internal mappings. 

Also, we need to keep around the old interface as well until it won't be supported anymore in Solidus.

For more details about the mappings change see https://github.com/solidusio/solidus/issues/3757