### PR TITLE
Add a method to check if combined address name is being used 

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
+require "rails/all"
 require "solidus_support"
 
 # You can add fixtures and/or initialization code here to make experimenting

--- a/lib/solidus_support.rb
+++ b/lib/solidus_support.rb
@@ -21,6 +21,16 @@ module SolidusSupport
       first_version_without_reset.satisfied_by?(Spree.solidus_gem_version)
     end
 
+    def combined_first_and_last_name_in_address?
+      versions_before_preference = Gem::Requirement.new('< 2.10')
+      versions_after_preference = Gem::Requirement.new('>= 3.0.0.alpha')
+
+      return false if versions_before_preference.satisfied_by?(Spree.solidus_gem_version)
+      return true if versions_after_preference.satisfied_by?(Spree.solidus_gem_version)
+
+      Spree::Config.use_combined_first_and_last_name_in_address
+    end
+
     def new_gateway_code?
       first_version_with_new_gateway_code = Gem::Requirement.new('>= 2.3')
       first_version_with_new_gateway_code.satisfied_by?(Spree.solidus_gem_version)

--- a/spec/solidus_support_spec.rb
+++ b/spec/solidus_support_spec.rb
@@ -42,4 +42,37 @@ RSpec.describe SolidusSupport do
     end
     # rubocop:enable RSpec/NestedGroups
   end
+
+  describe '.combined_first_and_last_name_in_address?' do
+    subject { described_class.combined_first_and_last_name_in_address? }
+
+    before do
+      allow(Spree).to receive(:solidus_gem_version) do
+        Gem::Version.new(solidus_version)
+      end
+    end
+
+    context 'when Solidus did not have the code to combine addresses fields' do
+      let(:solidus_version) { '2.9.3' }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'when Solidus has preference to choose if combine addresses fields' do
+      let(:solidus_version) { '2.10.3' }
+      before do
+        allow(Spree::Config)
+          .to receive(:use_combined_first_and_last_name_in_address)
+          .and_return(true)
+      end
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when Solidus only has code to combine addresses fields' do
+      let(:solidus_version) { '3.0.0' }
+
+      it { is_expected.to be_truthy }
+    end
+  end
 end


### PR DESCRIPTION
This helper method checks if a store is using the old or new way of setting the address' name.

It will act as a migration support to create conditional code to make extensions work compatible with both versions.

We can remove this method when the last 2.x version will reach EOL.

cc @filippoliverani 