### PR TITLE
Allow detecting Solidus components through a Rails setting

### DIFF
--- a/lib/solidus_support.rb
+++ b/lib/solidus_support.rb
@@ -68,15 +68,26 @@ module SolidusSupport
     end
 
     def frontend_available?
-      defined?(Spree::Frontend::Engine)
+      defined?(Spree::Frontend::Engine) ||
+        rails_config?(:frontend_available, true)
     end
 
     def backend_available?
-      defined?(Spree::Backend::Engine)
+      defined?(Spree::Backend::Engine) ||
+        rails_config?(:backend_available, true)
     end
 
     def api_available?
-      defined?(Spree::Api::Engine)
+      defined?(Spree::Api::Engine) ||
+        rails_config?(:api_available, true)
+    end
+
+    def rails_config?(name, value)
+      return false unless Rails.application
+
+      Rails.configuration.x.respond_to?(:solidus) &&
+        Rails.configuration.x.solidus.respond_to?(name) &&
+        (Rails.configuration.x.solidus.send(name) == value)
     end
   end
 end


### PR DESCRIPTION
This allows us to define solidus components at the application level, in
contrast to the typical engine definition.

Components paths are loaded on an initializer, which runs before the
application code that could define an `Engine` class. Adding a setting
on the `application.rb`, which runs before the initializers, helps us
working around it.

For now, we keep the old detection mechanism, as the other extensions
will need to adapt to it first.

References nebulab/solidus_starter_frontend#162