### PR TITLE
Remove deprecate_constant to separate method

### DIFF
--- a/lib/solidus_support/engine_extensions.rb
+++ b/lib/solidus_support/engine_extensions.rb
@@ -2,7 +2,11 @@
 
 module SolidusSupport
   module EngineExtensions
-    include ActiveSupport::Deprecation::DeprecatedConstantAccessor
+    def self.deprecate_constant(const_name, new_constant, message: nil, deprecator: ActiveSupport::Deprecation.instance)
+      class_variable_set(:@@_deprecated_constants, {}) unless class_variable_defined?(:@@_deprecated_constants)
+      class_variable_get(:@@_deprecated_constants)[const_name.to_s] = { new: new_constant, message: message, deprecator: deprecator }
+    end
+
     deprecate_constant 'Decorators', 'SolidusSupport::EngineExtensions'
 
     def self.included(engine)


### PR DESCRIPTION
The `deprecate_constant` method has only been moved to ActiveSupport::Deprecation::DeprecatedConstantAccessor in ActiveSupport5.2. This means that Rails versions prior to 5.2 will not be able to use SolidusSupport versions >=0.8.0.

Related Issue: #54 