### PR TITLE
Update `SolidusSupport.frontend_available?` to also check if SolidusStarterFrontend exists

### DIFF
--- a/lib/solidus_support.rb
+++ b/lib/solidus_support.rb
@@ -68,7 +68,7 @@ module SolidusSupport
     end
 
     def frontend_available?
-      defined?(Spree::Frontend::Engine)
+      defined?(Spree::Frontend::Engine) || defined?(SolidusStarterFrontend)
     end
 
     def backend_available?


### PR DESCRIPTION
Goal
----

We want to update `SolidusSupport.frontend_available?` to also check if
SolidusStarterFrontend exists so that extensions that call the method
can detect if an app has a storefront generated from the StarterFE
template.

## Background

This is part of an ongoing effort to transition from the SolidusFrontend gem to SolidusStarterFrontend.

https://user-images.githubusercontent.com/61476/155482788-ec1014a3-9c5f-4956-8d2e-9646fc269126.mp4

How does the Solidus ecosystem use `SolidusSupport.frontend_available?`
-----------------------------------------------------------------------

* An extension's engine checks if there is a frontend before adding its
  assets to the app's lib and precompile paths.

* The EngineExtensions module from SolidusSupport automatically adds the
  extension's frontend classes to the app's lib.

Requirements
------------

Given I have SolidusStarterFrontend installed on my Solidus app

When I call `SolidusSupport.frontend_available?`

Then it should return true