### PR TITLE
Add SolidusSupport.starter_frontend_available? to check if SolidusStarterFrontend exists

### DIFF
--- a/lib/solidus_support.rb
+++ b/lib/solidus_support.rb
@@ -71,6 +71,10 @@ module SolidusSupport
       defined?(Spree::Frontend::Engine)
     end
 
+    def starter_frontend_available?
+      defined?(SolidusStarterFrontend)
+    end
+
     def backend_available?
       defined?(Spree::Backend::Engine)
     end


### PR DESCRIPTION
Where does the Solidus ecosystem currently use `SolidusSupport.frontend_available?`
-----------------------------------------------------------------------------------

* The extension's engine checks if frontend is available before adding
  assets to the app's lib and precompile paths.

* The EngineExtensions module from SolidusSupport automatically adds the
  extension's frontend classes to the app's lib.

Why not just update `SolidusSupport.frontend_available?` to check if Starter FE is available?
---------------------------------------------------------------------------------------------

While updating `frontend_available?` doesn't seem to break an app that uses the
legacy SolidusFrontend gem, it currently doesn't work with
SolidusStarterFrontend. This is because the updated `frontend_available?`
allows SolidusAuthDevise to load its (legacy) frontend code to a Starter
FE-based app. SolidusStarterFrontend already generates its own authentication
frontend code, so the legacy frontend code that is loaded by SolidusAuthDevise
would conflict with the generated Starter FE authentication code.

It seems better to keep the definition of `frontend_available?` unchanged, that
is, for the method to refer to the legacy frontend gem.

See https://github.com/solidusio/solidus_support/pull/68 for a previous attempt to change `SolidusSupport.frontend_available?` to check if Starter FE is available.

Requirement
-----------

Given I have SolidusStarterFrontend installed on my Solidus app
When I call `SolidusSupport.starter_frontend_available?`
Then it should return true