### PR TITLE
Notify CI failures on Slack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,22 +6,35 @@ orbs:
   # to change this configuration every time a Solidus version is released
   # or goes EOL.
   solidusio_extensions: solidusio/extensions@volatile
+  slack: circleci/slack@4.9.3
+
+commands:
+  notify:
+      steps:
+        - slack/notify:
+            event: fail
+            template: basic_fail_1
+            branch_pattern: master
 
 jobs:
   run-specs-with-postgres:
     executor: solidusio_extensions/postgres
     steps:
       - solidusio_extensions/run-tests
+      - notify
   run-specs-with-mysql:
     executor: solidusio_extensions/mysql
     steps:
       - solidusio_extensions/run-tests
+      - notify
 
 workflows:
   "Run specs on supported Solidus versions":
     jobs:
-      - run-specs-with-postgres
-      - run-specs-with-mysql
+      - run-specs-with-postgres:
+          context: slack-secrets
+      - run-specs-with-mysql:
+          context: slack-secrets
   "Weekly run specs against master":
     triggers:
       - schedule:
@@ -31,5 +44,7 @@ workflows:
               only:
                 - master
     jobs:
-      - run-specs-with-postgres
-      - run-specs-with-mysql
+      - run-specs-with-postgres:
+          context: slack-secrets
+      - run-specs-with-mysql:
+          context: slack-secrets


### PR DESCRIPTION
## Summary

We use the [circleci/slack orb](https://circleci.com/developer/orbs/orb/circleci/slack) to notify whenever a CircleCI job fails. All jobs are included.

Currently, the CircleCI context has been configured to point to the [#ci-notifications](https://solidusio.slack.com/archives/C04C337T6P2)  channel on Solidus' [Slack workspace](https://soliidusio.slack.com), where we have created the [required Slack app](https://circleci.com/docs/slack-orb-tutorial/).

<img width="1526" alt="Screenshot 2022-11-18 at 05 25 51" src="https://user-images.githubusercontent.com/52650/202761161-c405a031-1277-407b-b721-0a9bc68e4acc.png">

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] I have used clear, explanatory commit messages.

The following are not always needed (~cross them out~ if they are not):

- ~[ ] I have added automated tests to cover my changes.~
- [x] I have attached screenshots to demo visual changes.
- ~[ ] I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).~
- ~[ ] I have updated the README to account for my changes.~

