### PR TITLE
Fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,20 +8,40 @@ orbs:
   solidusio_extensions: solidusio/extensions@volatile
 
 jobs:
-  run-specs-with-postgres:
-    executor: solidusio_extensions/postgres
+  run-specs:
+    parameters:
+      solidus:
+        type: string
+        default: master
+      db:
+        type: string
+        default: "postgres"
+      ruby:
+        type: string
+        default: "3.2"
+    executor:
+      name: solidusio_extensions/<< parameters.db >>
+      ruby_version: << parameters.ruby >>
     steps:
-      - solidusio_extensions/run-tests
-  run-specs-with-mysql:
-    executor: solidusio_extensions/mysql
-    steps:
-      - solidusio_extensions/run-tests
+      - checkout
+      - solidusio_extensions/run-tests-solidus-<< parameters.solidus >>
 
 workflows:
   "Run specs on supported Solidus versions":
     jobs:
-      - run-specs-with-postgres
-      - run-specs-with-mysql
+      - run-specs:
+          name: &name "run-specs-solidus-<< matrix.solidus >>-ruby-<< matrix.ruby >>-db-<< matrix.db >>"
+          matrix:
+            parameters: { solidus: ["master"], ruby: ["3.2"], db: ["postgres"] }
+      - run-specs:
+          name: *name
+          matrix:
+            parameters: { solidus: ["current"], ruby: ["3.1"], db: ["mysql"] }
+      - run-specs:
+          name: *name
+          matrix:
+            parameters: { solidus: ["older"], ruby: ["3.0"], db: ["sqlite"] }
+
   "Weekly run specs against master":
     triggers:
       - schedule:
@@ -31,5 +51,11 @@ workflows:
               only:
                 - master
     jobs:
-      - run-specs-with-postgres
-      - run-specs-with-mysql
+      - run-specs:
+          name: *name
+          matrix:
+            parameters: { solidus: ["master"], ruby: ["3.2"], db: ["postgres"] }
+      - run-specs:
+          name: *name
+          matrix:
+            parameters: { solidus: ["current"], ruby: ["3.1"], db: ["mysql"] }

--- a/spec/solidus_support/legacy_event_compat/legacy_event_compat_spec.rb
+++ b/spec/solidus_support/legacy_event_compat/legacy_event_compat_spec.rb
@@ -2,7 +2,7 @@
 
 require 'omnes'
 
-RSpec.describe SolidusSupport::LegacyEventCompat::Subscriber do
+RSpec.describe SolidusSupport::LegacyEventCompat::Subscriber, if: Spree.solidus_version < Gem::Version.new("4.0.0.dev") do
   subject { Module.new.include(Spree::Event::Subscriber).include(described_class) }
 
   describe '#omnes_subscriber' do


### PR DESCRIPTION
## Summary

### Only test old subscribers compatibility when legacy system is present

The legacy event system is [not available since v4.0](https://github.com/solidusio/solidus/pull/5024), so constants won't be available for testing.

### Update CI configuration

Run different Solidus versions on different jobs for better error handling.

We're now explicitly providing the ruby version to the executor while using a matrix configuration for better extensibility.- Only test old subscribers compatibility when legacy system is present

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
