### PR TITLE
Add lib/controllers/ENGINE to the autoload_paths

### DIFF
--- a/lib/solidus_support/engine_extensions.rb
+++ b/lib/solidus_support/engine_extensions.rb
@@ -107,14 +107,15 @@ module SolidusSupport
         end
 
         if SolidusSupport.send(:"#{engine}_available?")
-          path = root.join("lib/decorators/#{engine}")
-
-          config.autoload_paths += path.glob('*')
+          decorators_path = root.join("lib/decorators/#{engine}")
+          controllers_path = root.join("lib/controllers/#{engine}")
+          config.autoload_paths += decorators_path.glob('*')
+          config.autoload_paths += controllers_path.glob('*')
 
           engine_context = self
           config.to_prepare do
             engine_context.instance_eval do
-              load_solidus_decorators_from(path)
+              load_solidus_decorators_from(decorators_path)
             end
           end
         end


### PR DESCRIPTION
## Summary

SolidusSupport added `lib/decorators/#{engine}` to the autoload_paths, but there are no other autoloaded_paths for `lib`. This is a problem when the decorator tries to decorate an existing `class`, because it's not loaded yet.

A real example, happened on [solidus_social](https://github.com/solidusio-contrib/solidus_social/blob/eb542f3052430c208089366fc9ae458a9fe2d9a1/app/decorators/controllers/solidus_social/spree/user_registrations_controller_decorator.rb#L24), because it decorates a controller defined on [solidus_auth_devise](https://github.com/solidusio/solidus_auth_devise/blob/b3e431cbba29617bd862c80a4a3ed202ce7fb9c2/lib/controllers/frontend/spree/user_registrations_controller.rb).

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
