### PR TITLE
Don't skip the first namespace for controller paths

### DIFF
--- a/lib/solidus_support/engine_extensions.rb
+++ b/lib/solidus_support/engine_extensions.rb
@@ -110,7 +110,7 @@ module SolidusSupport
           decorators_path = root.join("lib/decorators/#{engine}")
           controllers_path = root.join("lib/controllers/#{engine}")
           config.autoload_paths += decorators_path.glob('*')
-          config.autoload_paths += controllers_path.glob('*')
+          config.autoload_paths << controllers_path if controllers_path.exist?
 
           engine_context = self
           config.to_prepare do


### PR DESCRIPTION
- Fixup to https://github.com/solidusio/solidus_support/pull/78
- Fixes https://github.com/solidusio/solidus_support/issues/79

## Summary


Autoload paths are meant to list autoload roots and not the first level of the namespace.

E.g. having the following controller in lib/controllers/solidus_foo:

    lib/controllers/solidus_foo/spree/my_controller.rb

The autoload will be triggered by a constant reference to `Spree::MyController` targeting `spree/my_controller.rb` inside `lib/controllers/solidus_foo/`. This means the autoload path needs to be `lib/controllers/solidus_foo/`.

See also https://edgeguides.rubyonrails.org/classic_to_zeitwerk_howto.html#globs-in-config-autoload-paths

<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
