### PR TITLE
Add `SolidusSupport.deprecator` and `.solidus_deprecator`

### DIFF
--- a/lib/solidus_support.rb
+++ b/lib/solidus_support.rb
@@ -12,6 +12,10 @@ module SolidusSupport
       @deprecator ||= ActiveSupport::Deprecation.new(Gem::Version.new('1.0'), 'SolidusSupport')
     end
 
+    def solidus_deprecator
+      Spree.solidus_gem_version >= Gem::Version.new('4.2') ? Spree.deprecator : Spree::Deprecation
+    end
+
     def solidus_gem_version
       deprecator.warn <<-WARN.squish, caller
         SolidusSupport.solidus_gem_version is deprecated and will be removed

--- a/lib/solidus_support.rb
+++ b/lib/solidus_support.rb
@@ -8,8 +8,12 @@ require 'solidus_core'
 
 module SolidusSupport
   class << self
+    def deprecator
+      @deprecator ||= ActiveSupport::Deprecation.new(Gem::Version.new('1.0'), 'SolidusSupport')
+    end
+
     def solidus_gem_version
-      ActiveSupport::Deprecation.warn <<-WARN.squish, caller
+      deprecator.warn <<-WARN.squish, caller
         SolidusSupport.solidus_gem_version is deprecated and will be removed
         in solidus_support 1.0. Please use Spree.solidus_gem_version instead.
       WARN
@@ -33,7 +37,7 @@ module SolidusSupport
     end
 
     def new_gateway_code?
-      ActiveSupport::Deprecation.warn <<-WARN.squish, caller
+      deprecator.warn <<-WARN.squish, caller
         SolidusSupport.new_gateway_code? is deprecated without replacement and will be removed
         in solidus_support 1.0.
       WARN
@@ -42,7 +46,7 @@ module SolidusSupport
     end
 
     def payment_source_parent_class
-      ActiveSupport::Deprecation.warn <<-WARN.squish, caller
+      deprecator.warn <<-WARN.squish, caller
         SolidusSupport.payment_source_parent_class is deprecated and will be removed
         in solidus_support 1.0. Please use Spree::PaymentSource instead.
       WARN
@@ -52,14 +56,14 @@ module SolidusSupport
 
     def payment_method_parent_class(credit_card: false)
       if credit_card
-        ActiveSupport::Deprecation.warn <<-WARN.squish, caller
+        deprecator.warn <<-WARN.squish, caller
           SolidusSupport.payment_method_parent_class(credit_card: true) is deprecated and will be removed
           in solidus_support 1.0. Please use Spree::PaymentMethod::CreditCard instead.
         WARN
 
         Spree::PaymentMethod::CreditCard
       else
-        ActiveSupport::Deprecation.warn <<-WARN.squish, caller
+        deprecator.warn <<-WARN.squish, caller
           SolidusSupport.payment_method_parent_class(credit_card: false) is deprecated and will be removed
           in solidus_support 1.0. Please use Spree::PaymentMethod instead.
         WARN

--- a/solidus_support.gemspec
+++ b/solidus_support.gemspec
@@ -1,32 +1,39 @@
 # frozen_string_literal: true
 
-$:.push File.expand_path('lib', __dir__)
-require 'solidus_support/version'
+require_relative 'lib/solidus_support/version'
 
-Gem::Specification.new do |s|
-  s.name = 'solidus_support'
-  s.version = SolidusSupport::VERSION
-  s.summary = 'Common runtime helpers for Solidus extensions.'
-  s.license = 'BSD-3-Clause'
+Gem::Specification.new do |spec|
+  spec.name = 'solidus_support'
+  spec.version = SolidusSupport::VERSION
+  spec.author = ['John Hawthorn', 'Solidus Team']
+  spec.email = 'contact@solidus.io'
 
-  s.author = 'John Hawthorn'
-  s.email = 'john@stembolt.com'
-  s.homepage = 'https://github.com/solidusio/solidus_support'
+  spec.summary = 'Common runtime helpers for Solidus extensions.'
+  spec.homepage = 'https://github.com/solidusio/solidus_support'
+  spec.license = 'BSD-3'
 
-  s.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  end
-  s.test_files = Dir['spec/**/*']
-  s.bindir = "exe"
-  s.executables = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  s.require_paths = ["lib"]
+  spec.metadata['homepage_uri'] = spec.homepage
+  spec.metadata['source_code_uri'] = 'https://github.com/solidusio/solidus_support'
+  spec.metadata['changelog_uri'] = 'https://github.com/solidusio/solidus_support/releases'
 
-  s.add_development_dependency 'rails'
-  s.add_development_dependency 'bundler'
-  s.add_development_dependency 'rake'
-  s.add_development_dependency 'rspec-rails'
-  s.add_development_dependency 'rubocop'
-  s.add_development_dependency 'rubocop-rspec'
-  s.add_development_dependency 'solidus_dev_support'
-  s.add_development_dependency 'omnes', '~> 0.2.2'
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.0')
+
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  files = Dir.chdir(__dir__) { `git ls-files -z`.split("\x0") }
+
+  spec.files = files.grep_v(%r{^(test|spec|features)/})
+  spec.test_files = files.grep(%r{^(test|spec|features)/})
+  spec.bindir = "exe"
+  spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ["lib"]
+
+  spec.add_development_dependency 'rails'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rspec-rails'
+  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop-rspec'
+  spec.add_development_dependency 'solidus_dev_support'
+  spec.add_development_dependency 'omnes', '~> 0.2.2'
 end

--- a/spec/solidus_support_spec.rb
+++ b/spec/solidus_support_spec.rb
@@ -71,4 +71,11 @@ RSpec.describe SolidusSupport do
       expect(described_class.deprecator.gem_name).to eq("SolidusSupport")
     end
   end
+
+  describe '.solidus_deprecator' do
+    it "references the Solidus deprecator without triggering deprecations" do
+      expect(described_class.solidus_deprecator).to be_a(ActiveSupport::Deprecation)
+      expect(described_class.solidus_deprecator.gem_name).to eq("Solidus")
+    end
+  end
 end

--- a/spec/solidus_support_spec.rb
+++ b/spec/solidus_support_spec.rb
@@ -2,7 +2,13 @@
 
 RSpec.describe SolidusSupport do
   describe '.payment_method_parent_class' do
-    subject { described_class.payment_method_parent_class(credit_card: credit_card) }
+    subject do
+      allow(described_class.deprecator).to receive(:warn).with(
+        a_string_matching(/payment_method_parent_class\b.* is deprecated/),
+        any_args,
+      )
+      described_class.payment_method_parent_class(credit_card: credit_card)
+    end
 
     let(:credit_card) { nil }
 
@@ -56,6 +62,13 @@ RSpec.describe SolidusSupport do
       let(:solidus_version) { '3.0.0' }
 
       it { is_expected.to be_truthy }
+    end
+  end
+
+  describe '.deprecator' do
+    it "is an instance of ActiveSupport::Deprecation specific to SolidusSupport" do
+      expect(described_class.deprecator).to be_a(ActiveSupport::Deprecation)
+      expect(described_class.deprecator.gem_name).to eq("SolidusSupport")
     end
   end
 end

--- a/spec/support/dummy_app.rb
+++ b/spec/support/dummy_app.rb
@@ -14,6 +14,9 @@ module DummyApp
   class Application < ::Rails::Application
     config.eager_load               = false
     config.paths['config/database'] = File.expand_path('dummy_app/database.yml', __dir__)
+    if ActiveRecord::VERSION::MAJOR >= 7
+      config.active_record.legacy_connection_handling = false
+    end
   end
 end
 

--- a/spec/support/dummy_app.rb
+++ b/spec/support/dummy_app.rb
@@ -20,4 +20,6 @@ module DummyApp
   end
 end
 
+Spree::Config.load_defaults Spree::VERSION
+
 DummyApp::Application.initialize!


### PR DESCRIPTION
## Summary

- Add the missing links to the rubygems entry
- Fix some deprecations inside specs 


<!--
  Please include a summary of your changes, along with any useful context.

  You're encouraged to include screenshots in case of visual changes.

  If needed, you can reference other PRs or issues here with #ISSUE-NUMBER.
  You can use GitHub-specific syntax, e.g.

  Fixes #ISSUE-NUMBER

  However, if you do not have merge permissions on the repo, issues won't be auto-closed.
-->

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [ ] I have written a thorough PR description.
- [ ] I have kept my commits small and atomic.
- [ ] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
