### PR TITLE
Add explicit deprecator for better Rails 7.1 compatibility

### DIFF
--- a/lib/solidus_support/engine_extensions.rb
+++ b/lib/solidus_support/engine_extensions.rb
@@ -3,7 +3,8 @@
 module SolidusSupport
   module EngineExtensions
     include ActiveSupport::Deprecation::DeprecatedConstantAccessor
-    deprecate_constant 'Decorators', 'SolidusSupport::EngineExtensions'
+    deprecator = Spree.respond_to?(:deprecator) ? Spree.deprecator : Spree::Deprecation
+    deprecate_constant 'Decorators', 'SolidusSupport::EngineExtensions', deprecator: deprecator
 
     def self.included(engine)
       engine.extend ClassMethods


### PR DESCRIPTION
This is now required starting from Rails 7.1, otherwise a warning appears:

    DEPRECATION WARNING: DeprecatedConstantAccessor.deprecate_constant
    without a deprecator is deprecated

This was introduced with rails/rails@6ce3dd9.

## Checklist

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages]The following are not always needed:
