### PR TITLE
Add support for SolidusAdmin

### DIFF
--- a/lib/solidus_support.rb
+++ b/lib/solidus_support.rb
@@ -80,5 +80,9 @@ module SolidusSupport
     def api_available?
       defined?(Spree::Api::Engine)
     end
+
+    def admin_available?
+      defined?(SolidusAdmin::Engine)
+    end
   end
 end

--- a/lib/solidus_support/engine_extensions.rb
+++ b/lib/solidus_support/engine_extensions.rb
@@ -18,6 +18,7 @@ module SolidusSupport
         enable_solidus_engine_support('backend')
         enable_solidus_engine_support('frontend')
         enable_solidus_engine_support('api')
+        enable_solidus_engine_support('admin')
       end
     end
 
@@ -109,8 +110,10 @@ module SolidusSupport
         if SolidusSupport.send(:"#{engine}_available?")
           decorators_path = root.join("lib/decorators/#{engine}")
           controllers_path = root.join("lib/controllers/#{engine}")
+          components_path = root.join("lib/components/#{engine}")
           config.autoload_paths += decorators_path.glob('*')
           config.autoload_paths << controllers_path if controllers_path.exist?
+          config.autoload_paths << components_path if components_path.exist?
 
           engine_context = self
           config.to_prepare do


### PR DESCRIPTION
For extension developers wishing to conditionally add support for the new Admin, we need to provide a space for components and controllers to go. Furthermore, we should have something like
`SolidusSupport.backend_available?` for the new admin. With this commit, I propose `SolidusSupport.admin_available?`
