### PR TITLE
Restrict SQLite to 1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ when 'mysql'
 when 'postgresql'
   gem 'pg'
 else
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.4'
 end
 
 gemspec


### PR DESCRIPTION
Sqlite 2 is out, but ActiveRecord does not know about it. As long as that is the case, we have to keep it on version 1.
