### PR TITLE
Zeitwerk: Use `#load` over `#require_dependency` for decorators

### DIFF
--- a/lib/solidus_support/engine_extensions.rb
+++ b/lib/solidus_support/engine_extensions.rb
@@ -53,7 +53,7 @@ module SolidusSupport
       # existing classes.
       def load_solidus_decorators_from(path)
         path.glob('**/*.rb') do |decorator_path|
-          require_dependency(decorator_path)
+          load(decorator_path)
         end
       end
 


### PR DESCRIPTION
According to the Rails Guide for Engines, in order to change functionality in an Engine at runtime, we should be using `load`. `require_dependency` is outdated. Here's the Rails guide from version 6.1, which is the last one that has `require_dependency` (only for the "classic" autoloading mode.

https://guides.rubyonrails.org/v6.1/engines.html#overriding-models-and-controllers
