### PR TITLE
Require "active_support/deprecation"

### DIFF
--- a/lib/solidus_support/engine_extensions.rb
+++ b/lib/solidus_support/engine_extensions.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "active_support/deprecation"
+
 module SolidusSupport
   module EngineExtensions
     include ActiveSupport::Deprecation::DeprecatedConstantAccessor


### PR DESCRIPTION
In some circumstances, it seems like it's possible for ActiveSupport not to be loaded when our engine extensions need them. Because we use the ActiveSupport::DeprecatedConstantAccessor in this file, it does not hurt to simply require the file.

Fixes #63