### PR TITLE
Support Flickwerk-style patches

### DIFF
--- a/lib/solidus_support/engine_extensions.rb
+++ b/lib/solidus_support/engine_extensions.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/deprecation"
+require "flickwerk"
 
 module SolidusSupport
   module EngineExtensions
@@ -9,6 +10,7 @@ module SolidusSupport
 
     def self.included(engine)
       engine.extend ClassMethods
+      engine.include Flickwerk
 
       engine.class_eval do
         solidus_decorators_root.glob('*') do |decorators_folder|
@@ -104,6 +106,17 @@ module SolidusSupport
             engine_context.instance_eval do
               load_solidus_decorators_from(decorators_path)
             end
+          end
+        end
+
+        initializer "#{name}_#{engine}_patch_paths", after: "flickwerk.add_paths" do
+          patch_paths = root.join("lib/patches/#{engine}").glob("*")
+          Flickwerk.patch_paths += patch_paths
+        end
+
+        initializer "#{name}_#{engine}_user_patches", before: "flickwerk.add_patches" do
+          Flickwerk.patches.transform_keys! do |key|
+            key.gsub("Spree.user_class", Spree.user_class_name)
           end
         end
       end

--- a/solidus_support.gemspec
+++ b/solidus_support.gemspec
@@ -28,6 +28,9 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'flickwerk', '~> 0.2.0'
+  spec.add_dependency 'solidus_core', '~> 4.1'
+
   spec.add_development_dependency 'rails'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
This enables using patches (i.e. "decorators"/"overrides") in Solidus engines, but using the style described in the [Flickwerk README](https://github.com/friendlycart/flickwerk/blob/main/README.md).

In short, this allows autoloading patches whenever the file being patches is loaded by Zeitwerk.

The new directory to put your patches into would be `app/patches`, and the files inside should be named `my_extension/spree_user_patch.rb` and define a constant `MyExtension::SpreeUserPatch`. The convention is that the module prepends itself to the class being patched, in this example `Spree::User`.



The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
