### PR TITLE
Remove call to `load_solidus_subscribers_from`

### DIFF
--- a/lib/solidus_support/engine_extensions.rb
+++ b/lib/solidus_support/engine_extensions.rb
@@ -27,7 +27,6 @@ module SolidusSupport
     module ClassMethods
       def activate
         load_solidus_decorators_from(solidus_decorators_root)
-        load_solidus_subscribers_from(solidus_subscribers_root)
       end
 
       # Loads decorator files.


### PR DESCRIPTION
We've removed this method in #88, but that didn't include removing this line.
