### PR TITLE
Fix: Add patch paths in `lib` BEFORE `flickwerk.add_paths`

### DIFF
--- a/lib/solidus_support/engine_extensions.rb
+++ b/lib/solidus_support/engine_extensions.rb
@@ -108,7 +108,7 @@ module SolidusSupport
           end
         end
 
-        initializer "#{name}_#{engine}_patch_paths", after: "flickwerk.add_paths" do
+        initializer "#{name}_#{engine}_patch_paths", before: "flickwerk.add_paths" do
           patch_paths = root.join("lib/patches/#{engine}").glob("*")
           Flickwerk.patch_paths += patch_paths
         end


### PR DESCRIPTION
The `flickwerk.add_paths` initializer adds patches to Rails' autoload paths, so any patches we want to add need to be present *before* they're added.
