### PR TITLE
Revert flickwerk

### DIFF
--- a/lib/solidus_support/engine_extensions.rb
+++ b/lib/solidus_support/engine_extensions.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "active_support/deprecation"
-require "flickwerk"
 
 module SolidusSupport
   module EngineExtensions
@@ -10,7 +9,6 @@ module SolidusSupport
 
     def self.included(engine)
       engine.extend ClassMethods
-      engine.include Flickwerk
 
       engine.class_eval do
         solidus_decorators_root.glob('*') do |decorators_folder|
@@ -105,17 +103,6 @@ module SolidusSupport
             engine_context.instance_eval do
               load_solidus_decorators_from(decorators_path)
             end
-          end
-        end
-
-        initializer "#{name}_#{engine}_patch_paths", after: "flickwerk.add_paths" do
-          patch_paths = root.join("lib/patches/#{engine}").glob("*")
-          Flickwerk.patch_paths += patch_paths
-        end
-
-        initializer "#{name}_#{engine}_user_patches", before: "flickwerk.add_patches" do
-          Flickwerk.patches.transform_keys! do |key|
-            key.gsub("Spree.user_class", Spree.user_class_name)
           end
         end
       end

--- a/lib/solidus_support/engine_extensions.rb
+++ b/lib/solidus_support/engine_extensions.rb
@@ -108,7 +108,7 @@ module SolidusSupport
           end
         end
 
-        initializer "#{name}_#{engine}_patch_paths", before: "flickwerk.add_paths" do
+        initializer "#{name}_#{engine}_patch_paths", after: "flickwerk.add_paths" do
           patch_paths = root.join("lib/patches/#{engine}").glob("*")
           Flickwerk.patch_paths += patch_paths
         end

--- a/solidus_support.gemspec
+++ b/solidus_support.gemspec
@@ -28,9 +28,6 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'flickwerk', '~> 0.2.0'
-  spec.add_dependency 'solidus_core', '~> 4.1'
-
   spec.add_development_dependency 'rails'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
**Reverts #90 and #92** 

Somehow the flickwerk dependency breaks many extensions and core gems in the whole Solidus ecosystem. 

Symptoms so far

- UI => Ui inflection is broken in solidus_admin
- bin/sandbox does not work because of constant nesting issues in solidus_paypal_commerce_platform
- Lookbook and ViewComponent previews are broken

Let's revert and then investigate what is happening 