### PR TITLE
Re-enable flickwerk-style patches

### DIFF
--- a/lib/solidus_support/engine_extensions.rb
+++ b/lib/solidus_support/engine_extensions.rb
@@ -113,9 +113,11 @@ module SolidusSupport
 
         if SolidusSupport.send(:"#{engine}_available?")
           decorators_path = root.join("lib/decorators/#{engine}")
+          patches_path = root.join("lib/patches/#{engine}")
           controllers_path = root.join("lib/controllers/#{engine}")
           components_path = root.join("lib/components/#{engine}")
           config.autoload_paths += decorators_path.glob('*')
+          config.autoload_paths += patches_path.glob("*")
           config.autoload_paths << controllers_path if controllers_path.exist?
           config.autoload_paths << components_path if components_path.exist?
 
@@ -132,9 +134,9 @@ module SolidusSupport
           Flickwerk.patch_paths += patch_paths
         end
 
-        initializer "#{name}_#{engine}_user_patches", before: "flickwerk.add_patches" do
-          Flickwerk.patches.transform_keys! do |key|
-            key.gsub("Spree.user_class", Spree.user_class_name)
+        initializer "#{name}_#{engine}_user_patches", before: "flickwerk.find_patches" do
+          app.reloader.to_prepare do
+            Flickwerk.aliases["Spree.user_class"] = Spree.user_class_name
           end
         end
       end

--- a/lib/solidus_support/engine_extensions.rb
+++ b/lib/solidus_support/engine_extensions.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_support/deprecation"
+require "flickwerk"
 
 module SolidusSupport
   module EngineExtensions
@@ -9,6 +10,7 @@ module SolidusSupport
 
     def self.included(engine)
       engine.extend ClassMethods
+      engine.include Flickwerk
 
       engine.class_eval do
         solidus_decorators_root.glob('*') do |decorators_folder|
@@ -122,6 +124,17 @@ module SolidusSupport
             engine_context.instance_eval do
               load_solidus_decorators_from(decorators_path)
             end
+          end
+        end
+
+        initializer "#{name}_#{engine}_patch_paths", before: "flickwerk.add_paths" do
+          patch_paths = root.join("lib/patches/#{engine}").glob("*")
+          Flickwerk.patch_paths += patch_paths
+        end
+
+        initializer "#{name}_#{engine}_user_patches", before: "flickwerk.add_patches" do
+          Flickwerk.patches.transform_keys! do |key|
+            key.gsub("Spree.user_class", Spree.user_class_name)
           end
         end
       end

--- a/lib/solidus_support/engine_extensions.rb
+++ b/lib/solidus_support/engine_extensions.rb
@@ -104,7 +104,7 @@ module SolidusSupport
         # by those gems, we work around those gems by adding our paths before
         # `initialize_cache`, which is the Rails initializer called before
         # `set_load_path`.
-        initializer "#{name}_#{engine}_paths", before: :initialize_cache do
+        initializer "#{engine_name}_#{engine}_paths", before: :initialize_cache do
           if SolidusSupport.send(:"#{engine}_available?")
             paths['app/controllers'] << "lib/controllers/#{engine}"
             paths['app/views'] << "lib/views/#{engine}"
@@ -129,12 +129,12 @@ module SolidusSupport
           end
         end
 
-        initializer "#{name}_#{engine}_patch_paths", before: "flickwerk.add_paths" do
+        initializer "#{engine_name}_#{engine}_patch_paths", before: "flickwerk.add_paths" do
           patch_paths = root.join("lib/patches/#{engine}").glob("*")
           Flickwerk.patch_paths += patch_paths
         end
 
-        initializer "#{name}_#{engine}_user_patches", before: "flickwerk.find_patches" do
+        initializer "#{engine_name}_#{engine}_user_patches", before: "flickwerk.find_patches" do
           app.reloader.to_prepare do
             Flickwerk.aliases["Spree.user_class"] = Spree.user_class_name
           end

--- a/solidus_support.gemspec
+++ b/solidus_support.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'flickwerk', '~> 0.2.0'
+  spec.add_dependency 'flickwerk', '~> 0.3.4'
   spec.add_dependency 'solidus_core', '~> 4.1'
 
   spec.add_development_dependency 'rails'

--- a/solidus_support.gemspec
+++ b/solidus_support.gemspec
@@ -28,6 +28,9 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'flickwerk', '~> 0.2.0'
+  spec.add_dependency 'solidus_core', '~> 4.1'
+
   spec.add_development_dependency 'rails'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
## Summary

We found out that we need to find and load patches in a config.to_prepare hook - the hard way, because Flickwerk 0.2 broke quite a few other gems and extensions. 

The new release has that fixes and offers a new API for class aliases like `"Spree.user_class" => "Spree::User"`. 

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).
