### PR TITLE
Deprecate SolidusSupport::Migration

### DIFF
--- a/lib/solidus_support/migration.rb
+++ b/lib/solidus_support/migration.rb
@@ -3,15 +3,10 @@
 module SolidusSupport
   module Migration
     def self.[](version)
-      if Rails.gem_version >= Gem::Version.new('5.x')
-        ActiveRecord::Migration[version]
-      else
-        # Rails < 5 doesn't support specifying rails version of migrations, but
-        # it _is_ rails 4.2, so we can use that when requested.
-        return ActiveRecord::Migration if version.to_s == '4.2'
-
-        raise ArgumentError, "Unknown migration version '#{version}'; expected one of '4.2'"
-      end
+      SolidusSupport.deprecator.warn(
+        "SolidusSupport::Migration[#{version}] is deprecated. Please use ActiveRecord::Migration[#{version}] instead."
+      )
+      ActiveRecord::Migration[version]
     end
   end
 end


### PR DESCRIPTION
Use `ActiveRecord::Migration` instead. Since we do not support Rails < 6.1 anymore we can simply remove the Rails <= 5.0 check as well.

Closes #56 