### PR TITLE
Deprecate `SolidusSupport::LegacyEventCompat::Bus`

### DIFF
--- a/lib/solidus_support/legacy_event_compat/bus.rb
+++ b/lib/solidus_support/legacy_event_compat/bus.rb
@@ -23,6 +23,10 @@ module SolidusSupport
       # @param event_name [Symbol]
       # @param payload [Hash<Symbol, Any>]
       def self.publish(event_name, **payload)
+        SolidusSupport.deprecator.warn(
+          "SolidusSupport::LegacyEventCompat::Bus is deprecated and will be removed in solidus_support 1.0." \
+          " Please use Spree::Bus.publish instead."
+        )
         if SolidusSupport::LegacyEventCompat.using_legacy?
           Spree::Event.fire(event_name, payload)
         else

--- a/lib/solidus_support/legacy_event_compat/subscriber.rb
+++ b/lib/solidus_support/legacy_event_compat/subscriber.rb
@@ -41,6 +41,10 @@ module SolidusSupport
       end
 
       def self.included(legacy_subscriber)
+        SolidusSupport.deprecator.warn(
+          "SolidusSupport::LegacyEventCompat::Subscriber is deprecated and will be removed in solidus_support 1.0." \
+          " Please `include Omnes::Subscriber` in `#{legacy_subscriber.name}` instead."
+        )
         legacy_subscriber.define_singleton_method(:omnes_subscriber) do
           @omnes_subscriber ||= Class.new.include(::Omnes::Subscriber).tap do |subscriber|
             legacy_subscriber.event_actions.each do |(legacy_subscriber_method, event_name)|


### PR DESCRIPTION
and `SolidusSupport::LegacyEventCompat::Subscriber`

The new `Spree::Bus` is available since Solidus 3.2
