### PR TITLE
Remove call to legacy_connection_handling 

### DIFF
--- a/spec/support/dummy_app.rb
+++ b/spec/support/dummy_app.rb
@@ -14,9 +14,6 @@ module DummyApp
   class Application < ::Rails::Application
     config.eager_load               = false
     config.paths['config/database'] = File.expand_path('dummy_app/database.yml', __dir__)
-    if ActiveRecord::VERSION::MAJOR >= 7 && ActiveRecord::VERSION::MINOR < 1
-      config.active_record.legacy_connection_handling = false
-    end
   end
 end
 


### PR DESCRIPTION
This setting doesn't actually do anything from Rails 7 onwards, and is
removed in Rails 7.1. Remove it.
