### PR TITLE
Fix setting flickwerk Spree.user_class alias

### DIFF
--- a/lib/solidus_support/engine_extensions.rb
+++ b/lib/solidus_support/engine_extensions.rb
@@ -37,16 +37,16 @@ module SolidusSupport
       # This allows to add event subscribers to extensions without explicitly subscribing them,
       # similarly to what happens in Solidus core.
       def load_solidus_subscribers_from(path)
-        if SolidusSupport::LegacyEventCompat.using_legacy?
-          path.glob("**/*_subscriber.rb") do |subscriber_path|
-            require_dependency(subscriber_path)
-          end
+        return unless SolidusSupport::LegacyEventCompat.using_legacy?
 
-          if Spree::Event.respond_to?(:activate_all_subscribers)
-            Spree::Event.activate_all_subscribers
-          else
-            Spree::Event.subscribers.each(&:subscribe!)
-          end
+        path.glob("**/*_subscriber.rb") do |subscriber_path|
+          require_dependency(subscriber_path)
+        end
+
+        if Spree::Event.respond_to?(:activate_all_subscribers)
+          Spree::Event.activate_all_subscribers
+        else
+          Spree::Event.subscribers.each(&:subscribe!)
         end
       end
 

--- a/lib/solidus_support/engine_extensions.rb
+++ b/lib/solidus_support/engine_extensions.rb
@@ -136,7 +136,11 @@ module SolidusSupport
 
         initializer "#{engine_name}_#{engine}_user_patches" do |app|
           app.reloader.to_prepare do
-            Flickwerk.aliases["Spree.user_class"] = Spree.user_class_name
+            Flickwerk.aliases["Spree.user_class"] = if Spree.respond_to?(:user_class_name)
+                                                      Spree.user_class_name
+                                                    else
+                                                      Spree.user_class.name
+                                                    end
           end
         end
 


### PR DESCRIPTION
## Summary

The `Spree.user_class_name` getter was introduced in
Solidus 4.4.2 and we still support older versions.

## Checklist

Check out our [PR guidelines](https://github.com/solidusio/.github/blob/master/CONTRIBUTING.md#pull-request-guidelines) for more details.

The following are mandatory for all PRs:

- [x] [I agree that my PR will be published under the same license as Solidus](https://github.com/solidusio/solidus/blob/main/LICENSE.md).
- [x] I have written a thorough PR description.
- [x] I have kept my commits small and atomic.
- [x] [I have used clear, explanatory commit messages](https://github.com/solidusio/.github/blob/main/CONTRIBUTING.md#writing-good-commit-messages).

The following are not always needed:

- 📖 I have updated the README to account for my changes.
- 📑 I have documented new code [with YARD](https://www.rubydoc.info/gems/yard/file/docs/Tags.md).
- 🛣️ I have opened a PR to update the [guides](https://github.com/solidusio/edgeguides).
- ✅ I have added automated tests to cover my changes.
- 📸 I have attached screenshots to demo visual changes.
